### PR TITLE
feat: only deploy certain branches to Staging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,11 +4,9 @@ on:
   push:
     tags-ignore:
       - '**' # do not run on tags
-    branches:
-      - '**'
+    branches: [ "main", "staging/**" ]
   pull_request:
-    branches:
-      - '**'
+    branches: [ "main", "staging/**" ]
 
 jobs:
   test:
@@ -28,8 +26,9 @@ jobs:
         run: npm run lint && npm run test
 
   staging-deploy:
-    needs: test
     name: Deploy to staging
+    needs: test
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     environment: staging
     steps:
@@ -58,8 +57,8 @@ jobs:
             npm install --production
 
   staging-install:
-    needs: staging-deploy
     name: Install staging to Confluence
+    needs: staging-deploy
     environment: staging
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +76,7 @@ jobs:
   draft-release:
     name: Create Draft release
     needs: staging-install
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Workflows will now be triggered exclusively by pushes and PRs on the main or staging/** branches, and only the test job will run for PRs.
